### PR TITLE
Hotfix/iframe

### DIFF
--- a/src/resumable.js
+++ b/src/resumable.js
@@ -42,10 +42,6 @@ let isBinary = function(obj){
 	return isFile || isBlob
 };
 
-let isFile = function(obj){
-	return Object.prototype.toString.call(obj) === '[object File]';
-};
-
 let wrapEventCallback = function(eventCallback){
 	eventCallback = eventCallback || function(){};
 	return function(t, eventParam, result){

--- a/src/resumable.js
+++ b/src/resumable.js
@@ -36,6 +36,16 @@ let isFunction = function(obj){
 	return Object.prototype.toString.call(obj) === '[object Function]';
 };
 
+let isBinary = function(obj){
+	const isFile = Object.prototype.toString.call(obj) === '[object File]';
+	const isBlob = Object.prototype.toString.call(obj) === '[object Blob]';
+	return isFile || isBlob
+};
+
+let isFile = function(obj){
+	return Object.prototype.toString.call(obj) === '[object File]';
+};
+
 let wrapEventCallback = function(eventCallback){
 	eventCallback = eventCallback || function(){};
 	return function(t, eventParam, result){
@@ -306,7 +316,7 @@ let startToUploadFile = function(ctx){
 			};
 			
 			
-			if(ctx.verifyMd5 && window.FileReader && ((ctx.uploadCheckpoint.sourceFile instanceof window.File) || (ctx.uploadCheckpoint.sourceFile instanceof window.Blob))){
+			if(ctx.verifyMd5 && window.FileReader && isBinary(ctx.uploadCheckpoint.sourceFile)){
 				let _sourceFile = sliceBlob(ctx.uploadCheckpoint.sourceFile, part.offset, part.offset + part.partSize);
 				let fr = new window.FileReader();
 				fr.onload = function(e){	
@@ -371,7 +381,7 @@ resumable.extend = function(ObsClient){
 		
 		if(!uploadCheckpoint){
 			let sourceFile = param.SourceFile;
-			if(!(sourceFile instanceof window.File) && !(sourceFile instanceof window.Blob)){
+			if(!isBinary(sourceFile)){
 				return _callback('source file is not valid, must be an instanceof [File | Blob]');
 			}
 			
@@ -439,7 +449,7 @@ resumable.extend = function(ObsClient){
 			uploadCheckpoint.md5 = calculateUploadCheckpointMD5(uploadCheckpoint);
 		}else{
 			let sourceFile = uploadCheckpoint.sourceFile;
-			if(!(sourceFile instanceof window.File) && !(sourceFile instanceof window.Blob)){
+			if(!isBinary(sourceFile)){
 				return _callback('source file is not valid, must be an instanceof [File | Blob]');
 			}
 			


### PR DESCRIPTION
场景：
UEditor 上传视频是通过 iframe 方式
obs 上传是在主窗口定义和调用 `obs.uploadFile({ SourceFile:file })`
UEditor 上传视频拿到 `file` 对象后, 调用主窗口上传方法 `window.parent.obs.uploadFile({ SourceFile:file })`
问题：
用 `file instanceof window.File` 判断 file 传参类型会报错，因为 `file` 对象是在 iframe 生成，原型指向的是 iframe 作用域的 File, 而不是主窗口的 window.File
方案：
用`Object.prototype.toString.call(...)`代替 `instanceof window.File`进行类型判断

